### PR TITLE
test: list shelters on admin index page

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,0 +1,6 @@
+class AdminController < ApplicationController
+
+  def index
+    @shelters = Shelter.reverse_alphabetical
+  end
+end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -31,4 +31,8 @@ class Shelter < ApplicationRecord
   def shelter_pets_filtered_by_age(age_filter)
     adoptable_pets.where('age >= ?', age_filter)
   end
+
+  def self.reverse_alphabetical
+    find_by_sql("SELECT * FROM shelters ORDER BY name desc")
+  end
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,0 +1,6 @@
+<h1> Admin Shelters </h1>
+<h3> All Shelters </h3>
+
+  <% @shelters.each do |shelter| %>
+    <p><%= shelter.name %></p>
+  <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   get '/', to: 'application#welcome'
 
+  get '/admin/shelters', to: 'admin#index'
+
   get '/shelters', to: 'shelters#index'
   get '/shelters/new', to: 'shelters#new'
   get '/shelters/:id', to: 'shelters#show'

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe do
+  before :each do
+    @shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
+    @shelter_2 = Shelter.create(name: 'RGV animal shelter', city: 'Harlingen, TX', foster_program: false, rank: 5)
+    @shelter_3 = Shelter.create(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)
+  end
+
+  it 'can list shelters in reverse alphabetical order' do
+    visit '/admin/shelters'
+save_and_open_page
+    expect(@shelter_2.name).to appear_before(@shelter_3.name)
+    expect(@shelter_3.name).to appear_before(@shelter_1.name)
+    expect(@shelter_1.name).to_not appear_before(@shelter_2.name)
+    expect(@shelter_3.name).to_not appear_before(@shelter_2.name)
+  end
+end

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -32,6 +32,12 @@ RSpec.describe Shelter, type: :model do
       it 'returns partial matches' do
         expect(Shelter.search("Fancy")).to eq([@shelter_3])
       end
+
+    describe '#reverse_alphabetical' do
+      it 'returns all shelters in reverse alphabetical order' do
+        expect(Shelter.reverse_alphabetical).to eq([@shelter_2, @shelter_3, @shelter_1])
+      end
+    end
     end
 
     describe '#order_by_recently_created' do


### PR DESCRIPTION
What does this PR do? 

It lists all shelters on an admin index page in reverse alphabetical order. Created admin feature test to test reverse order appearance. Then created route for admin index page. Then created admin index view iterating through shelters. Since search was in SQL on all shelters, created class method in shelter model using sql DSL, along with commensurate test to ensure objects appear in reverse order. Called method in admin controller by method name. Verified using save_and_open_page.